### PR TITLE
feat: capture and show errors in the scoring processing

### DIFF
--- a/components/ControlPanel/ControlPanel.jsx
+++ b/components/ControlPanel/ControlPanel.jsx
@@ -3,6 +3,8 @@ import axios from 'axios';
 import { Button, Grid } from '@material-ui/core';
 import CompareIcon from '@material-ui/icons/Compare';
 import PropTypes from 'prop-types';
+import Snackbar from '@material-ui/core/Snackbar';
+import Alert from '@material-ui/lab/Alert';
 import { JsonFileDropContainer } from '~/components/JsonFileDropContainer';
 import { ScoreCard } from '~/components/ScoreCard';
 import { OptionsPanel } from '~/components/OptionsPanel/OptionsPanel';
@@ -14,6 +16,15 @@ export const ControlPanel = ({ onScoreChange }) => {
   const [jsonB, setJsonB] = useState();
   const [scoringResults, setScoringResults] = useState({});
   const [options, setOptions] = useState(DEFAULT_OPTIONS);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const dismissErrorMessage = (event, reason) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+
+    setErrorMessage('');
+  };
 
   const handleChange = (setJson) => (files) => {
     files.forEach((file) => {
@@ -33,7 +44,7 @@ export const ControlPanel = ({ onScoreChange }) => {
         onScoreChange(data);
       })
       .catch((err) => {
-        console.log('error in request', err); // ToDo: properly catch errors.
+        setErrorMessage(err.response?.data || err.messageData);
       });
   };
 
@@ -53,14 +64,24 @@ export const ControlPanel = ({ onScoreChange }) => {
             <CompareIcon />
             Compare
           </Button>
+          <Snackbar
+            anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+            open={errorMessage.length > 0}
+            onClose={dismissErrorMessage}
+            autoHideDuration={6000}
+          >
+            <Alert severity="error" onClose={dismissErrorMessage}>
+              {errorMessage}
+            </Alert>
+          </Snackbar>
           <ScoreCard score={scoringResults.scoreNumber} />
         </Grid>
       </Grid>
       <OptionsPanel />
     </OptionsProvider>
-
   );
 };
+
 ControlPanel.propTypes = {
   onScoreChange: PropTypes.func,
 };

--- a/components/JsonFileDropContainer.jsx
+++ b/components/JsonFileDropContainer.jsx
@@ -40,7 +40,7 @@ export const JsonFileDropContainer = ({ onChange, text }) => {
         dropzoneClass={classes.dropzone}
         getFileAddedMessage={(fileName) => `${fileName} successfully added.`}
         previewGridProps={{ container: { justify: 'center', direction: 'row' } }}
-        acceptedFiles={['application/json']}
+        acceptedFiles={['application/json', '.txt']}
       />
     </Card>
   );

--- a/cypress/fixtures/acceptance/BreweriesMaster-broken.txt
+++ b/cypress/fixtures/acceptance/BreweriesMaster-broken.txt
@@ -1,0 +1,61 @@
+{
+  "state": "MT",
+  "state-bird": "Western Meadowloark",
+  "state-fish": "Cutthroat Trout",
+  "breweries": [
+    {
+      "name": "Madison River Brewing",
+      "location": {
+        "address": "20900 Frontage Rd Building B",
+        "city": "Belgrade",
+        "state": "MT",
+        "zip-code": "59714"
+      },
+      "food-available": false,
+      "beers": {[
+        {
+          "name": "Salmon Fly Honey Rye",
+          "color": "Gold",
+          "international-bitterness-units": 12,
+          "alcohol-by-volume": 0.04
+        },
+        {
+          "name": "Copper John Scotch Ale",
+          "color": "Copper",
+          "international-bitterness-units": 35,
+          "alcohol-by-volume": 0.055
+        },
+        {
+          "name": "Dropper IPA",
+          "color": "Amber",
+          "international-bitterness-units": 108,
+          "alcohol-by-volume": 0.065
+        }
+      ]
+    },
+    {
+      "name": "Bozeman Brewing",
+      "location": {
+        "address": "504 N. Broadway",
+        "city": "Bozeman",
+        "state": "MT",
+        "zip-code": "59715"
+      },
+      "food-available": true,
+      "beers": [
+        {
+          "name": "Bozone Amber Ale",
+          "color": "Amber",
+          "international-bitterness-units": 29,
+          "alcohol-by-volume": 0.054
+        },
+        {
+          "name": "Plum Street Porter",
+          "color": "Dark",
+          "international-bitterness-units": 52,
+          "alcohol-by-volume": 0.06
+        }
+      ]
+    }
+  ]
+}

--- a/cypress/integration/app.spec.js
+++ b/cypress/integration/app.spec.js
@@ -101,5 +101,20 @@ describe('The scoring app', () => {
         cy.contains('35.7%');
       });
     });
+    ['A', 'B'].map((fileLetter) => describe(`when the File ${fileLetter} is not valid JSONs`, () => {
+      it('should shown an error message', () => {
+        // arrange
+        const goodFile = 'BreweriesMaster.json';
+        const brokenFile = 'BreweriesMaster-broken.txt';
+        cy.drop('File A', goodFile);
+        cy.drop('File B', goodFile);
+        cy.drop(`File ${fileLetter}`, brokenFile);
+        // act
+        cy.contains('Compare').click();
+
+        // assert
+        cy.contains(`Could not parse json${fileLetter} param as a JSON object`);
+      });
+    }));
   });
 });


### PR DESCRIPTION
Right now, if, for instance, the uploaded JSON is broken, it will return a 422 code from the backend but the end-user will not have a clue of what happened.